### PR TITLE
Fix Android 12 Target-SDK 31+ issues

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,7 +72,7 @@
 
 
     <config-file target="AndroidManifest.xml" parent="/*/application">
-      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true">
+      <receiver android:name="nl.xservices.plugins.ShareChooserPendingIntent" android:enabled="true" android:exported="true">
         <intent-filter>
           <action android:name="android.intent.action.SEND"/>
         </intent-filter>

--- a/src/android/nl/xservices/plugins/SocialSharing.java
+++ b/src/android/nl/xservices/plugins/SocialSharing.java
@@ -271,7 +271,15 @@ public class SocialSharing extends CordovaPlugin {
         final boolean hasMultipleAttachments = files.length() > 1;
         final Intent sendIntent = new Intent(hasMultipleAttachments ? Intent.ACTION_SEND_MULTIPLE : Intent.ACTION_SEND);
         final Intent receiverIntent = new Intent(cordova.getActivity().getApplicationContext(), ShareChooserPendingIntent.class);
-        final PendingIntent pendingIntent = PendingIntent.getBroadcast(cordova.getActivity().getApplicationContext(), 0, receiverIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        
+        int pendingIntentValueFLAG = 0;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+          pendingIntentValueFLAG = PendingIntent.FLAG_MUTABLE;
+        } else {
+          pendingIntentValueFLAG = PendingIntent.FLAG_UPDATE_CURRENT;
+        }
+        final PendingIntent pendingIntent = PendingIntent.getBroadcast(cordova.getActivity().getApplicationContext(), 0, receiverIntent, pendingIntentValueFLAG);
+        
         sendIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
 
         try {


### PR DESCRIPTION
- Since Android 12+ it is required to explicitly set the
android:exported property when the corresponding component
 has an intent filter defined.
- Fixes the following Android 12+ issue:
java.lang.IllegalArgumentException: com.app-xxx: Targeting S+
(version 31 and above) requires that one of FLAG_IMMUTABLE or
FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE
if some functionality depends on the PendingIntent being mutable,
e.g. if it needs to be used with inline replies or bubbles.